### PR TITLE
chore(deps): update blade-ui-kit/blade-icons to 1.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0]
-        laravel: [^7.0, ^8.0]
+        php: [7.4, 8.0]
+        laravel: [^8.0]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ For a full list of available icons see [the SVG directory](resources/svg) or pre
 
 ## Requirements
 
-- PHP 7.3 or higher
-- Laravel 7.14 or higher
+- PHP 7.4 or higher
+- Laravel 8.0 or higher
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
         }
     ],
     "require": {
-        "php": "^7.3||^8.0",
-        "blade-ui-kit/blade-icons": "^0.5",
-        "illuminate/support": "^7.14|^8.0"
+        "php": "^7.4|^8.0",
+        "blade-ui-kit/blade-icons": "^1.0",
+        "illuminate/support": "^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.17",
-        "orchestra/testbench": "^5.0|^6.0",
-        "phpunit/phpunit": "^8.0|^9.0"
+        "orchestra/testbench": "^6.0",
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This also removes support for PHP 7.3 and Laravel 7, as Blade Icons 1.x no longer supports those. 👍🏻